### PR TITLE
Preserve accumulator after clearing Zinger

### DIFF
--- a/BNW-post-2.1-modifications-main/ASM/near_fatal_zinger_clear.asm
+++ b/BNW-post-2.1-modifications-main/ASM/near_fatal_zinger_clear.asm
@@ -1,6 +1,6 @@
 hirom
 
-!freeZinger = $C4B6D5
+!freeZinger = $C4B6EE
 
 org $C2FBA0
 Vulnerables1:
@@ -12,7 +12,7 @@ org $C207C8
 ClearZinger:
 
 ; Most of this is copied verbatim from BNW repo
-; This claims 8 of the 9 unused bytes in the routine
+; This claims all 9 unused bytes in the routine
 ; to add a helper for clearing Zinger when Near Fatal
 
 org $C24517
@@ -48,6 +48,7 @@ OvercastFix:
   PHP                ; preserve flags
   PHX                ; preserve X
   JML ZingerHelper   ; clear zinger/charm/love token
+  PLA                ; restore low byte of A
   PLX                ; restore X
   PLP                ; restore flags
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -77,12 +78,12 @@ OvercastFix:
   PLA                ; restore status-to-set-1/2
   STA $FC            ; save ^
   RTS
-  RTS                ; 1 unused byte (was RTS previously, preserving out of caution)
 
 org !freeZinger
 ZingerHelper:
   TSB $FC            ; to-set "Near Fatal"
   TYX                ; store target in X
   SEP #$20           ; 8-bit A
+  PHA                ; stash low byte of A
   PEA $4555          ; set return address for ClearZinger
   JML ClearZinger    ; clear Zinger, Love Token, Charm variables


### PR DESCRIPTION
This prevents the accumulator from being polluted after clearing Zinger/Love Token/etc. It goes into that routine with `0x0200` and would often return with something like `0x02FF`, which would also result in clearing things like Poison, Imp, Blind and (perhaps catastrophically) Magitek, among others.

Now the original value of `0x0200` is preserved so that when the Near Fatal flag is cleared, it doesn't have any additional side effects.